### PR TITLE
dummy makefile

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1,12 +1,10 @@
 all:
 
 install:
-	. /etc/environ.sh; use -e -r anaconda-6; python -m compileall ../site-packages
 
 clean:
 
 distclean: clean
-	find ../site-packages -name "*.pyc" -exec /bin/rm -f {} \;
 
 .PHONY: all install clean distclean
 


### PR DESCRIPTION
Spoke with Steven Clark, and he said Jupyter apps should only have a dummy makefile. The Makefile should be blank, but should still be there. The Makefile itself doesn't do anything. 